### PR TITLE
Add qawanted to keywords

### DIFF
--- a/bugbug/models/qaneeded.py
+++ b/bugbug/models/qaneeded.py
@@ -24,7 +24,7 @@ class QANeededModel(Model):
             bug_features.has_str(),
             bug_features.has_regression_range(),
             bug_features.severity(),
-            bug_features.keywords(),
+            bug_features.keywords(set(['qawanted'])),
             bug_features.is_coverity_issue(),
             bug_features.has_crash_signature(),
             bug_features.has_url(),


### PR DESCRIPTION
Added the `qawanted` keyword to `bugfeatures.keywords()` in case of qaneeded classification.

Fixes #21.