### PR TITLE
Code reference url token.

### DIFF
--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -182,6 +182,11 @@ class component(object):
 
 
 def cleanup_url(text):
+    mozilla_text = ['mozilla', 'fox', 'bugzilla']
+    for mozilla_keyword in mozilla_text:
+        if mozilla_keyword in text:
+            return re.sub(r'http\S+', 'CODE_REFERENCE_URL', text)
+
     return re.sub(r'http\S+', 'URL', text)
 
 

--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -182,11 +182,7 @@ class component(object):
 
 
 def cleanup_url(text):
-    mozilla_text = ['mozilla', 'fox', 'bugzilla']
-    for mozilla_keyword in mozilla_text:
-        if mozilla_keyword in text:
-            return re.sub(r'http\S+', 'CODE_REFERENCE_URL', text)
-
+    text = re.sub(r'http[s]?://(hg.mozilla|searchfox|dxr.mozilla)\S+', 'CODE_REFERENCE_URL', text)
     return re.sub(r'http\S+', 'URL', text)
 
 

--- a/tests/test_cleanup_functions.py
+++ b/tests/test_cleanup_functions.py
@@ -9,6 +9,9 @@ from bugbug import bug_features
 def test_cleanup_url():
     tests = [
         ('This code lies in https://github.com/marco-c/bugbug', 'This code lies in URL'),
+        ('Another url can be https://hg.mozilla.org/camino/ or https://google.com', 'Another url can be CODE_REFERENCE_URL or URL'),
+        ('Third example is https://searchfox.org and http://hg.mozilla.org', 'Third example is CODE_REFERENCE_URL and CODE_REFERENCE_URL'),
+        ('More generic links can be https://github.com/marco-c/bugbug , https://hg.mozilla.org/try/ and https://searchfox.org', 'More generic links can be URL , CODE_REFERENCE_URL and CODE_REFERENCE_URL')
     ]
     for orig_text, cleaned_text in tests:
         assert bug_features.cleanup_url(orig_text) == cleaned_text


### PR DESCRIPTION
Added a new "CODE_REFERENCE_URL" to cleanup_url function. It tests for the presence of words starting with `https://hg.mozilla` or `https://searchfox` and replaces them with this token.