### PR TITLE
Remove referred text in comments

### DIFF
--- a/bugbug/bug_features.py
+++ b/bugbug/bug_features.py
@@ -182,19 +182,23 @@ class component(object):
 
 
 def cleanup_url(text):
-    text = re.sub(r'http[s]?://(hg.mozilla|searchfox|dxr.mozilla)\S+', 'CODE_REFERENCE_URL', text)
-    return re.sub(r'http\S+', 'URL', text)
+    text = re.sub(r'http[s]?://(hg.mozilla|searchfox|dxr.mozilla)\S+', '__CODE_REFERENCE_URL__', text)
+    return re.sub(r'http\S+', '__URL__', text)
 
 
 def cleanup_fileref(text):
-    return re.sub(r'\w+\.py\b|\w+\.json\b|\w+\.js\b|\w+\.jsm\b|\w+\.html\b|\w+\.css\b|\w+\.c\b|\w+\.cpp\b|\w+\.h\b', 'FILE_REFERENCE', text)
+    return re.sub(r'\w+\.py\b|\w+\.json\b|\w+\.js\b|\w+\.jsm\b|\w+\.html\b|\w+\.css\b|\w+\.c\b|\w+\.cpp\b|\w+\.h\b', '__FILE_REFERENCE__', text)
+
+
+def cleanup_comments(text):
+    return re.sub('>.*?\\n', ' ', text)
 
 
 class BugExtractor(BaseEstimator, TransformerMixin):
     def __init__(self, feature_extractors, commit_messages_map=None):
         self.feature_extractors = feature_extractors
         self.commit_messages_map = commit_messages_map
-        self.cleanup_functions = [cleanup_url, cleanup_fileref]
+        self.cleanup_functions = [cleanup_url, cleanup_fileref, cleanup_comments]
 
     def fit(self, x, y=None):
         return self

--- a/tests/test_cleanup_functions.py
+++ b/tests/test_cleanup_functions.py
@@ -8,10 +8,10 @@ from bugbug import bug_features
 
 def test_cleanup_url():
     tests = [
-        ('This code lies in https://github.com/marco-c/bugbug', 'This code lies in URL'),
-        ('Another url can be https://hg.mozilla.org/camino/ or https://google.com', 'Another url can be CODE_REFERENCE_URL or URL'),
-        ('Third example is https://searchfox.org and http://hg.mozilla.org', 'Third example is CODE_REFERENCE_URL and CODE_REFERENCE_URL'),
-        ('More generic links can be https://github.com/marco-c/bugbug , https://hg.mozilla.org/try/ and https://searchfox.org', 'More generic links can be URL , CODE_REFERENCE_URL and CODE_REFERENCE_URL')
+        ('This code lies in https://github.com/marco-c/bugbug', 'This code lies in __URL__'),
+        ('Another url can be https://hg.mozilla.org/camino/ or https://google.com', 'Another url can be __CODE_REFERENCE_URL__ or __URL__'),
+        ('Third example is https://searchfox.org and http://hg.mozilla.org', 'Third example is __CODE_REFERENCE_URL__ and __CODE_REFERENCE_URL__'),
+        ('More generic links can be https://github.com/marco-c/bugbug , https://hg.mozilla.org/try/ and https://searchfox.org', 'More generic links can be __URL__ , __CODE_REFERENCE_URL__ and __CODE_REFERENCE_URL__')
     ]
     for orig_text, cleaned_text in tests:
         assert bug_features.cleanup_url(orig_text) == cleaned_text
@@ -19,7 +19,16 @@ def test_cleanup_url():
 
 def test_cleanup_fileref():
     tests = [
-        ('Some random filenames are file1.py , file2.cpp and file3.json', 'Some random filenames are FILE_REFERENCE , FILE_REFERENCE and FILE_REFERENCE'),
+        ('Some random filenames are file1.py , file2.cpp and file3.json', 'Some random filenames are __FILE_REFERENCE__ , __FILE_REFERENCE__ and __FILE_REFERENCE__'),
     ]
     for orig_text, cleaned_text in tests:
         assert bug_features.cleanup_fileref(orig_text) == cleaned_text
+
+
+def test_cleanup_comments():
+    tests = [
+        ('Some text > This is the comment \nend of line', 'Some text  end of line'),
+        ('Multiline comments > This is the first line\n>This is the second line\nEnd of comments', 'Multiline comments   End of comments')
+    ]
+    for orig_text, cleaned_text in tests:
+        assert bug_features.cleanup_comments(orig_text) == cleaned_text


### PR DESCRIPTION
Added a new cleanup function to remove all text referred in comments (starting with `>` and ending with newline `\n`). Also changed the previous tokens according to the updated comment in #9 